### PR TITLE
added var in details

### DIFF
--- a/schemas/hotel-details/index.ts
+++ b/schemas/hotel-details/index.ts
@@ -100,14 +100,12 @@ export const details: FeatureSchemaDefinition = {
         value: "details.card.room-specification",
       },
       {
-        title:
-          "[Details] Right Media Aspect Ratio[2:4] with Top Left Layover content",
-        value: "details.card.right-media-aspect-ratio-2:4-with-top-left-layover-content",
+        title: "[Details] Semi Image with overlapped content",
+        value: "details.card.semi-image-with-overlapped-content",
       },
       {
-        title:
-          "[Details] Media Aspect Ratio[1:4] with Bottom Right Layover Content",
-        value: "details.card.media-aspect-ratio-1:4-bottom-right-layover-content",
+        title: "[Details] Full Image with overlapped content",
+        value: "details.card.full-image-with-overlapped-content",
       },
       {
         title: "[Details] Left Media Image carousal with right Content",

--- a/schemas/hotel-details/index.ts
+++ b/schemas/hotel-details/index.ts
@@ -99,6 +99,36 @@ export const details: FeatureSchemaDefinition = {
         title: "[Details] Room Specification",
         value: "details.card.room-specification",
       },
+      {
+        title:
+          "[Details] Right Media Aspect Ratio[2:4] with Top Left Layover content",
+        value: "details.card.right-media-ar-2:4-with-top-left-layover-content",
+      },
+      {
+        title:
+          "[Details] Media Aspect Ratio[1:4] with Bottom Right Layover Content",
+        value: "details.card.media-ar-1:4-bottom-right-layover-content",
+      },
+      {
+        title: "[Details] Left Media Image carousal with right Content",
+        value: "details.card.left-media-image-carousel-with-right-content",
+      },
+      {
+        title: "[Details] Venue Enquiry Model Form",
+        value: "details.card.venue-enquiry-model-form",
+      },
+      {
+        title: "[Details] Venue Quote Model Form",
+        value: "details.card.venue-quote-model-form",
+      },
+      {
+        title: "[Details] Wellness Enquiry Model Form",
+        value: "details.card.wellness-enquiry-model-form",
+      },
+      {
+        title: "[Details] Experience Enquiry Model Form",
+        value: "details.card.experience-enquiry-model-form",
+      },
     ],
     banner: [],
     dialog: [
@@ -110,6 +140,10 @@ export const details: FeatureSchemaDefinition = {
       {
         title: "[Details] Gallery With Carousel",
         value: "details.gallery-with-carousel",
+      },
+      {
+        title: "[Details] Hotel Accommodation and its General Information",
+        value: "details.dialog.hotel-accommodation-and-general-information",
       },
     ],
   },

--- a/schemas/hotel-details/index.ts
+++ b/schemas/hotel-details/index.ts
@@ -102,12 +102,12 @@ export const details: FeatureSchemaDefinition = {
       {
         title:
           "[Details] Right Media Aspect Ratio[2:4] with Top Left Layover content",
-        value: "details.card.right-media-ar-2:4-with-top-left-layover-content",
+        value: "details.card.right-media-aspect-ratio-2:4-with-top-left-layover-content",
       },
       {
         title:
           "[Details] Media Aspect Ratio[1:4] with Bottom Right Layover Content",
-        value: "details.card.media-ar-1:4-bottom-right-layover-content",
+        value: "details.card.media-aspect-ratio-1:4-bottom-right-layover-content",
       },
       {
         title: "[Details] Left Media Image carousal with right Content",

--- a/schemas/ihcl-authentication/index.ts
+++ b/schemas/ihcl-authentication/index.ts
@@ -71,6 +71,10 @@ export const Authentication: FeatureSchemaDefinition = {
         title: "[Authentication] Mobile Number Registration",
         value: "authentication.dialog.mobile-number-registration",
       },
+      {
+        title: "[Authentication] OTP Login Model",
+        value: "authentication.dialog.otp-login-model",
+      },
     ],
     tabs: [
       {

--- a/schemas/ihcl-partners/index.ts
+++ b/schemas/ihcl-partners/index.ts
@@ -5,8 +5,8 @@ export const partners: FeatureSchemaDefinition = {
         group:[],
         card:[
             {
-                title:"[partners] Image Carousel",
-                value:"partners.card.image-carousel"
+                title:"[partners] Right Media Image Carousel with Left Content",
+                value:"partners.card.right-media-image-carousel-with-left-content"
             }
         ]
     }


### PR DESCRIPTION
added card and dialog varaints for detail enquiry popup models:

[Details] Hotel Accommodation and its General Information
<img width="314" alt="image" src="https://user-images.githubusercontent.com/120178389/225587011-daf46191-8ea9-427e-9354-947f55b8b0b2.png">

[Details] Venue Enquiry Model Form
<img width="366" alt="image" src="https://user-images.githubusercontent.com/120178389/225587257-d684dcfb-53a1-41e2-b131-55209d64c841.png">

[Details] Venue Quote Model Form
<img width="350" alt="image" src="https://user-images.githubusercontent.com/120178389/225587524-2fdb0752-a0c7-42e0-be1c-f649dcffc047.png">

[Details] Wellness Enquiry Model Form
<img width="413" alt="image" src="https://user-images.githubusercontent.com/120178389/225587659-f2f06d87-a5d8-45df-882f-4ccaa3177cc6.png">

[Details] Experience Enquiry Model Form
<img width="404" alt="image" src="https://user-images.githubusercontent.com/120178389/225587848-371518d1-a960-4aa3-a8d0-dfbc9a38f489.png">

[Details] Left Media Image carousal with right Content
<img width="412" alt="image" src="https://user-images.githubusercontent.com/120178389/225588284-5840d54f-585d-4859-a99e-2e5ca8f371e3.png">

[partners] Right Media Image Carousel with Left Content [modified this variant]
<img width="321" alt="image" src="https://user-images.githubusercontent.com/120178389/225588532-b8fff947-8614-4551-be16-b989c82bc373.png">


